### PR TITLE
🪛 Typo: correct Github to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@
 
 1. 登入您的 OneManager 後台，並進入設定
 2. 選擇 **`首頁`** 頁面
-3. 在 **`Update from`** 選擇 `Github` `TW527E` `OneManager-php` `master`
+3. 在 **`Update from`** 選擇 `GitHub` `TW527E` `OneManager-php` `master`
 4. 點擊 **`一鍵更新`**
 5. 等待更新，完成
 

--- a/readme_zh-cn.md
+++ b/readme_zh-cn.md
@@ -73,7 +73,7 @@
 
 1. 登录您的 OneManager 后台，并进入设置
 2. 选择 **`首页`** 页面
-3. 在 **`Update from`** 选择 `Github` `TW527E` `OneManager-php` `master`
+3. 在 **`Update from`** 选择 `GitHub` `TW527E` `OneManager-php` `master`
 4. 点击 **`一鍵更新`**
 5. 等待更新，完成
 

--- a/renexmoe-tw527e-edition-elemecdn.html
+++ b/renexmoe-tw527e-edition-elemecdn.html
@@ -286,7 +286,7 @@
       <!--MultiDiskAreaEnd-->
       <a target="_blank" href="https://github.com/qkqpttgf/OneManager-php" class="mdui-list-item mdui-ripple">
         <i class="mdui-list-item-icon mdui-icon material-icons">code</i>
-        <div class="mdui-list-item-content">Github</div>
+        <div class="mdui-list-item-content">GitHub</div>
       </a>
       <li class="mdui-list-item mdui-ripple" id="about_theme">
         <i class="mdui-list-item-icon mdui-icon material-icons">info</i>

--- a/renexmoe-tw527e-edition-jsdelivr-cdn.html
+++ b/renexmoe-tw527e-edition-jsdelivr-cdn.html
@@ -286,7 +286,7 @@
       <!--MultiDiskAreaEnd-->
       <a target="_blank" href="https://github.com/qkqpttgf/OneManager-php" class="mdui-list-item mdui-ripple">
         <i class="mdui-list-item-icon mdui-icon material-icons">code</i>
-        <div class="mdui-list-item-content">Github</div>
+        <div class="mdui-list-item-content">GitHub</div>
       </a>
       <li class="mdui-list-item mdui-ripple" id="about_theme">
         <i class="mdui-list-item-icon mdui-icon material-icons">info</i>

--- a/renexmoe-tw527e-edition-jsdelivr-fastly.html
+++ b/renexmoe-tw527e-edition-jsdelivr-fastly.html
@@ -286,7 +286,7 @@
       <!--MultiDiskAreaEnd-->
       <a target="_blank" href="https://github.com/qkqpttgf/OneManager-php" class="mdui-list-item mdui-ripple">
         <i class="mdui-list-item-icon mdui-icon material-icons">code</i>
-        <div class="mdui-list-item-content">Github</div>
+        <div class="mdui-list-item-content">GitHub</div>
       </a>
       <li class="mdui-list-item mdui-ripple" id="about_theme">
         <i class="mdui-list-item-icon mdui-icon material-icons">info</i>

--- a/renexmoe-tw527e-edition-jsdelivr-gcore.html
+++ b/renexmoe-tw527e-edition-jsdelivr-gcore.html
@@ -286,7 +286,7 @@
       <!--MultiDiskAreaEnd-->
       <a target="_blank" href="https://github.com/qkqpttgf/OneManager-php" class="mdui-list-item mdui-ripple">
         <i class="mdui-list-item-icon mdui-icon material-icons">code</i>
-        <div class="mdui-list-item-content">Github</div>
+        <div class="mdui-list-item-content">GitHub</div>
       </a>
       <li class="mdui-list-item mdui-ripple" id="about_theme">
         <i class="mdui-list-item-icon mdui-icon material-icons">info</i>

--- a/renexmoe-tw527e-edition-jsdelivr-originfastly.html
+++ b/renexmoe-tw527e-edition-jsdelivr-originfastly.html
@@ -286,7 +286,7 @@
       <!--MultiDiskAreaEnd-->
       <a target="_blank" href="https://github.com/qkqpttgf/OneManager-php" class="mdui-list-item mdui-ripple">
         <i class="mdui-list-item-icon mdui-icon material-icons">code</i>
-        <div class="mdui-list-item-content">Github</div>
+        <div class="mdui-list-item-content">GitHub</div>
       </a>
       <li class="mdui-list-item mdui-ripple" id="about_theme">
         <i class="mdui-list-item-icon mdui-icon material-icons">info</i>

--- a/renexmoe-tw527e-edition-statically.html
+++ b/renexmoe-tw527e-edition-statically.html
@@ -286,7 +286,7 @@
       <!--MultiDiskAreaEnd-->
       <a target="_blank" href="https://github.com/qkqpttgf/OneManager-php" class="mdui-list-item mdui-ripple">
         <i class="mdui-list-item-icon mdui-icon material-icons">code</i>
-        <div class="mdui-list-item-content">Github</div>
+        <div class="mdui-list-item-content">GitHub</div>
       </a>
       <li class="mdui-list-item mdui-ripple" id="about_theme">
         <i class="mdui-list-item-icon mdui-icon material-icons">info</i>

--- a/renexmoe-tw527e-edition.html
+++ b/renexmoe-tw527e-edition.html
@@ -286,7 +286,7 @@
       <!--MultiDiskAreaEnd-->
       <a target="_blank" href="https://github.com/qkqpttgf/OneManager-php" class="mdui-list-item mdui-ripple">
         <i class="mdui-list-item-icon mdui-icon material-icons">code</i>
-        <div class="mdui-list-item-content">Github</div>
+        <div class="mdui-list-item-content">GitHub</div>
       </a>
       <li class="mdui-list-item mdui-ripple" id="about_theme">
         <i class="mdui-list-item-icon mdui-icon material-icons">info</i>


### PR DESCRIPTION
Just a minor fix which corrects `Github` to `GitHub`, seems it didn't break anything.

Nice design by the way, definitely the best OneManager theme I've ever seen. :3